### PR TITLE
Fix: Update `get_card_detail` prompt to prevent `print_id` prediction

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -229,13 +229,12 @@ This tool provides:
 - Publication details (set, rarity, artist)
 - All available card variations
 
-IMPORTANT USAGE SEQUENCE:
-1. FIRST use search_fab_cards to get the cardId
-2. THEN use get_fab_card_prints with that cardId to check available print variations
-3. ONLY THEN use this tool with both the cardId and appropriate printId
+IMPORTANT USAGE SEQUENCE AND WARNINGS:
+1. FIRST use search_fab_cards to get the cardId.
+2. THEN use get_fab_card_prints with that cardId to check available print variations. This is the ONLY way to find the correct printId for a specific language (e.g., Japanese).
+3. ONLY THEN use this tool with both the cardId and the ACCURATE printId obtained from get_fab_card_prints.
 
-If a specific language variant doesn't appear in get_fab_card_prints results, 
-the card is not available in that language.`,
+DO NOT attempt to guess or predict the printId. If you need a card in a specific language (e.g., Japanese), you MUST use get_fab_card_prints to find the correct printId for that language. If a specific language variant (e.g. Japanese) or its printId does not appear in the get_fab_card_prints results, the card is not available in that language, and you should NOT use this tool for that language.`,
 			{ 
 				cardId: z.string(), 
 				printId: z.string().optional() 


### PR DESCRIPTION
The previous prompt for the `get_card_detail` action sometimes led me to incorrectly predict the `print_id` when a Japanese version of a card was requested.

This change updates the action's description to include a stronger warning against guessing the `print_id` and explicitly states that `get_fab_card_prints` must be used to find the correct `print_id` for any specific language, including Japanese.