### PR TITLE
Configure Renovate to refresh yarn lockfile

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,20 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
-  ]
+  ],
+  "packageRules": [
+    {
+      "matchManagers": [
+        "npm"
+      ],
+      "enabled": false
+    }
+  ],
+  "postUpgradeTasks": {
+    "executionMode": "branch",
+    "commands": [
+      "corepack enable",
+      "yarn install --mode=update-lockfile"
+    ]
+  }
 }


### PR DESCRIPTION
## Summary
- add Renovate postUpgradeTasks to regenerate yarn.lock during upgrade branches
- disable the npm manager so Renovate only touches the Yarn ecosystem

## Testing
- yarn format *(fails: command not found: biome)*
- yarn lint:fix *(fails: command not found: biome)*

------
https://chatgpt.com/codex/tasks/task_e_68ca28021f40833395ae23ea53e6f481