### PR TITLE
Renovate設定からリポジトリで許可できないコマンド設定を削除

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,10 +3,6 @@
   "extends": [
     "config:recommended"
   ],
-  "allowedPostUpgradeCommands": [
-    "corepack enable",
-    "yarn install --mode=update-lockfile"
-  ],
   "postUpgradeTasks": {
     "executionMode": "branch",
     "commands": [


### PR DESCRIPTION
## 概要
- Renovate の設定からリポジトリで指定できない `allowedPostUpgradeCommands` を削除し、設定警告を解消

## テスト
- `yarn format` （`biome` が未インストールのため失敗）
- `yarn lint:fix` （`biome` が未インストールのため失敗）

------
https://chatgpt.com/codex/tasks/task_e_68ca2fb01b788333a2abe03df65bc31b