### PR TITLE
fix: zod依存関係のバージョン不整合を解消

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
 		"axios": "^1.11.0",
 		"cheerio": "^1.1.2",
 		"pino": "^9.7.0",
-		"zod": "^4.0.0"
+                "zod": "^3.25.76"
 	},
 	"packageManager": "yarn@4.9.4+sha512.7b1cb0b62abba6a537b3a2ce00811a843bea02bcf53138581a6ae5b1bf563f734872bd47de49ce32a9ca9dcaff995aa789577ffb16811da7c603dcf69e73750b"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -527,27 +527,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@modelcontextprotocol/sdk@npm:^1.13.3":
-  version: 1.18.0
-  resolution: "@modelcontextprotocol/sdk@npm:1.18.0"
-  dependencies:
-    ajv: "npm:^6.12.6"
-    content-type: "npm:^1.0.5"
-    cors: "npm:^2.8.5"
-    cross-spawn: "npm:^7.0.5"
-    eventsource: "npm:^3.0.2"
-    eventsource-parser: "npm:^3.0.0"
-    express: "npm:^5.0.1"
-    express-rate-limit: "npm:^7.5.0"
-    pkce-challenge: "npm:^5.0.0"
-    raw-body: "npm:^3.0.0"
-    zod: "npm:^3.23.8"
-    zod-to-json-schema: "npm:^3.24.1"
-  checksum: 10c0/73ee91a2f72bdbb9cb9ed1a20f0c35d8ba7439d34b0fb5143814834504b6b244462a5789f30ebe72568c07b4a2cf0ac5a3c15009832f5d0e9a644178f3b8f2ca
-  languageName: node
-  linkType: hard
-
-"@modelcontextprotocol/sdk@npm:^1.18.0":
+"@modelcontextprotocol/sdk@npm:^1.13.3, @modelcontextprotocol/sdk@npm:^1.18.0":
   version: 1.18.0
   resolution: "@modelcontextprotocol/sdk@npm:1.18.0"
   dependencies:
@@ -2459,7 +2439,7 @@ __metadata:
     pino: "npm:^9.7.0"
     typescript: "npm:^5.8.3"
     wrangler: "npm:^4.26.0"
-    zod: "npm:^4.0.0"
+    zod: "npm:^3.25.76"
   languageName: unknown
   linkType: soft
 
@@ -3163,16 +3143,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zod@npm:^3.23.8, zod@npm:^3.25.67, zod@npm:^3.25.76":
+"zod@npm:^3.23.8, zod@npm:^3.25.76":
   version: 3.25.76
   resolution: "zod@npm:3.25.76"
   checksum: 10c0/5718ec35e3c40b600316c5b4c5e4976f7fee68151bc8f8d90ec18a469be9571f072e1bbaace10f1e85cf8892ea12d90821b200e980ab46916a6166a4260a983c
-  languageName: node
-  linkType: hard
-
-"zod@npm:^4.0.0":
-  version: 4.1.9
-  resolution: "zod@npm:4.1.9"
-  checksum: 10c0/8aa2f240a3ccd153feb061f8ef17b9a4c2bcc98f1146c16655f8623c628c7376006fb70c5e1adcb655fc3585b848435eec307c5bf690cfedbdb220c567e62075
   languageName: node
   linkType: hard


### PR DESCRIPTION
## 概要
- zodの依存バージョンを^3.25.76に修正し、lockfileとの不整合を解消しました
- yarn.lockを整理して@modelcontextprotocol/sdkの重複定義と不要なzod@^4エントリを取り除きました

## テスト
- yarn format（`biome`コマンドが見つからず失敗）
- yarn lint:fix（`biome`コマンドが見つからず失敗）

------
https://chatgpt.com/codex/tasks/task_e_68ca4653d6b483339ae775392762e671