### PR TITLE
feat: add CardVault products listing tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The official FAB card database has moved to `cardvault.fabtcg.com` and uses a ne
 
 - Analysis date: 2026-03-07
 - Investigation + migration design: [`docs/cardvault-api-analysis.md`](docs/cardvault-api-analysis.md)
-- Implementation status: `search_fab_cards` / `get_fab_card_prints` / `get_card_detail` now use CardVault API (`api.cardvault.fabtcg.com`)
+- Implementation status: `search_fab_cards` / `get_fab_card_prints` / `get_card_detail` / `get_fab_products` now use CardVault API (`api.cardvault.fabtcg.com`)
 
 ## Features
 
@@ -31,6 +31,14 @@ Retrieve all print variations of a specific card using its card ID. Returns info
 - Print images (small, normal, large sizes)
 - Layout information
 - Finish types available
+
+### 3. Product Catalog Lookup (`get_fab_products`)
+
+Retrieve product groups shown on `cardvault.fabtcg.com/products`, including:
+- Product group name and type
+- Release dates
+- Nested product entries (slug, language, printed date)
+- Pagination metadata (`next`, `previous`, `nextPage`, `previousPage`)
 
 ## Deployment
 

--- a/docs/cardvault-api-analysis.md
+++ b/docs/cardvault-api-analysis.md
@@ -11,6 +11,7 @@
 | --- | --- | --- |
 | カード検索 | `GET https://api.cardvault.fabtcg.com/carddb/api/v1/advanced-search/?q=<query>&page_size=60&orderby=name` | 一覧画面で使用。`advanced-search`（末尾 `/` なし）へアクセスすると `301`。 |
 | カード詳細（カード単位） | `GET https://api.cardvault.fabtcg.com/carddb/api/v1/card_id/<card_id>/` | 詳細画面で使用。`card_prints` に印刷違い・言語違いがまとまって返る。 |
+| 製品一覧（Products） | `GET https://api.cardvault.fabtcg.com/carddb/api/v1/product-groups-products/?page=<n>` | `/products` 画面で使用。初回はクエリなし、続きは `page` でページング。 |
 | ランディング画像 | `GET https://api.cardvault.fabtcg.com/carddb/api/v1/splash-image/` | ホーム表示用。MCP ツールでは未使用。 |
 | API ルート | `GET https://api.cardvault.fabtcg.com/carddb/api/v1/` | 一部公開エンドポイント一覧を返す。 |
 
@@ -21,6 +22,7 @@
 | `search_fab_cards` | `cards.fabtcg.com/api/search/v1/cards/` | `advanced-search` に置換。 |
 | `get_fab_card_prints` | `cards.fabtcg.com/api/fab/v1/prints/` | `card_id/<card_id>/` の `card_prints` を利用。 |
 | `get_card_detail` | `cards.fabtcg.com/card/...` の HTML スクレイピング | `card_id/<card_id>/` の JSON を直接利用（スクレイピング廃止）。 |
+| `get_fab_products` | なし（新規） | `product-groups-products/` を利用し、Products 画面相当の一覧を返す。 |
 
 ### 重要なフィールド差分
 - 旧 `search` の `display_name` / `url` は新 API にはない。
@@ -65,6 +67,7 @@
 - 旧 API では存在したが新 API にない値（`display_name` など）は互換のために代替値で埋める。
 - `card_id/<card_id>/` が `200 + results: []` を返すケースがあるため、空配列を明示的にハンドリングする。
 - `advanced-search` のレスポンスは印刷単位寄りなので、必要に応じて同一 `card_id` の重複を許容/抑制する方針を実装前に決める。
+- `product-groups-products` はページング (`page`) を返す。`page` が範囲外だと `404 {"detail":"Invalid page."}` になるため、呼び出し側でのハンドリングが必要。
 - 実装後は `cheerio` の依存削除可否を確認する。
 
 ## 実装後の検証項目（予定）
@@ -80,6 +83,8 @@
   - `search_fab_cards` -> `advanced-search/`
   - `get_fab_card_prints` -> `card_id/<card_id>/` の `card_prints`
   - `get_card_detail` -> `card_id/<card_id>/` JSON から詳細を構築
+- `get_fab_products` を追加。
+  - `product-groups-products/` を呼び、`page` 付きページング情報と製品グループ一覧を返す
 - `get_card_detail` の HTML スクレイピング（`cheerio`）はコード上で撤廃済み。
 
 ## 実装後の検証結果（このブランチ）

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
 		"axios": "^1.11.0",
 		"cheerio": "^1.1.2",
 		"pino": "^9.7.0",
-                "zod": "^3.25.76"
+		"zod": "^3.25.76"
 	},
 	"packageManager": "yarn@4.9.4+sha512.7b1cb0b62abba6a537b3a2ce00811a843bea02bcf53138581a6ae5b1bf563f734872bd47de49ce32a9ca9dcaff995aa789577ffb16811da7c603dcf69e73750b"
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -88,6 +88,25 @@ interface CardDetail {
     }>;
 }
 
+interface ProductSummary {
+    id: string;
+    productName: string;
+    slug?: string;
+    language?: string;
+    printedDate?: string;
+    productType?: string;
+    releaseDate?: string;
+    description?: string;
+}
+
+interface ProductGroupSummary {
+    id: string;
+    groupName: string;
+    productType?: string;
+    releaseDate?: string;
+    products: ProductSummary[];
+}
+
 // CardVault API 型
 interface CardVaultImage {
     small?: string;
@@ -157,6 +176,25 @@ interface CardVaultCardRecord {
     card_id?: string;
     cores?: CardVaultCore[];
     card_prints?: CardVaultCardPrint[];
+}
+
+interface CardVaultProductGroupProduct {
+    id?: string;
+    product_name?: string | null;
+    slug?: string | null;
+    printed_language?: string | null;
+    printed_date?: string | null;
+    product_type?: string | null;
+    release_date?: string | null;
+    description?: string | null;
+}
+
+interface CardVaultProductGroup {
+    id?: string;
+    group_name?: string | null;
+    product_type?: string | null;
+    release_date?: string | null;
+    products?: CardVaultProductGroupProduct[];
 }
 
 interface CardVaultListResponse<T> {
@@ -265,6 +303,26 @@ function buildVariants(cardId: string, cardPrints: CardVaultCardPrint[]): CardDe
     return Array.from(variants.values());
 }
 
+function parsePageNumberFromUrl(urlText: string | null): number | undefined {
+    const resolvedUrlText = asOptionalString(urlText);
+    if (!resolvedUrlText) {
+        return undefined;
+    }
+
+    try {
+        const url = new URL(resolvedUrlText);
+        const pageParam = asOptionalString(url.searchParams.get("page"));
+        if (!pageParam) {
+            return undefined;
+        }
+
+        const parsedPage = Number.parseInt(pageParam, 10);
+        return Number.isFinite(parsedPage) && parsedPage > 0 ? parsedPage : undefined;
+    } catch {
+        return undefined;
+    }
+}
+
 async function requestCardVault<T>(
     path: string,
     params?: Record<string, string | number | undefined>,
@@ -310,7 +368,7 @@ export class MyMCP extends McpAgent {
         name: "Flesh and Blood Card Search API",
         version: "1.0.0",
         description:
-            "Search cards, review print variations, and access detailed data from the Flesh and Blood Trading Card Game database",
+            "Search cards, review print variations, browse product catalogs, and access detailed data from the Flesh and Blood Trading Card Game database",
     });
 
     async init() {
@@ -684,6 +742,117 @@ Notes:
             },
         );
 
+        // CardVault の製品グループ一覧を取得
+        this.server.tool(
+            "get_fab_products",
+            `Retrieve product groups from cardvault.fabtcg.com/products.
+
+This tool provides:
+- Product groups and their nested product entries
+- Product metadata (language, slug, printed/release date, type)
+- Pagination metadata for navigating large result sets
+
+Input:
+- page (optional): Page number (default: 1)`,
+            {
+                page: z.number().int().min(1).optional(),
+            },
+            async ({ page }) => {
+                const resolvedPage = page ?? 1;
+
+                try {
+                    logger.info(
+                        {
+                            tool: "get_fab_products",
+                            action: "fetch_start",
+                            page: resolvedPage,
+                        },
+                        "製品一覧取得開始",
+                    );
+
+                    const data = await requestCardVault<CardVaultListResponse<CardVaultProductGroup>>(
+                        "/product-groups-products/",
+                        { page: resolvedPage },
+                    );
+
+                    const productGroups: ProductGroupSummary[] = data.results.map((group) => ({
+                        id: asOptionalString(group.id) ?? "",
+                        groupName: asOptionalString(group.group_name) ?? "",
+                        productType: asOptionalString(group.product_type),
+                        releaseDate: asOptionalString(group.release_date),
+                        products: (group.products ?? []).map((product) => ({
+                            id: asOptionalString(product.id) ?? "",
+                            productName: asOptionalString(product.product_name) ?? "",
+                            slug: asOptionalString(product.slug),
+                            language: asOptionalString(product.printed_language)?.toUpperCase(),
+                            printedDate: asOptionalString(product.printed_date),
+                            productType: asOptionalString(product.product_type),
+                            releaseDate: asOptionalString(product.release_date),
+                            description: asOptionalString(product.description),
+                        })),
+                    }));
+
+                    logger.info(
+                        {
+                            tool: "get_fab_products",
+                            action: "api_response",
+                            page: resolvedPage,
+                            resultCount: data.results.length,
+                            totalCount: data.count,
+                        },
+                        "製品一覧APIレスポンス受信",
+                    );
+
+                    return {
+                        content: [{
+                            type: "text",
+                            text: JSON.stringify(
+                                {
+                                    page: resolvedPage,
+                                    count: data.count,
+                                    next: data.next,
+                                    previous: data.previous,
+                                    nextPage: parsePageNumberFromUrl(data.next),
+                                    previousPage: parsePageNumberFromUrl(data.previous),
+                                    productGroups,
+                                },
+                                null,
+                                2,
+                            ),
+                        }],
+                    };
+                } catch (error) {
+                    const errorMessage = error instanceof Error ? error.message : "Unknown error occurred";
+                    const axiosStatus =
+                        axios.isAxiosError(error) && typeof error.response?.status === "number"
+                            ? error.response.status
+                            : undefined;
+                    const isInvalidPageError = axiosStatus === 404;
+
+                    logger.error(
+                        {
+                            tool: "get_fab_products",
+                            action: "error",
+                            error: errorMessage,
+                            page: resolvedPage,
+                            status: axiosStatus ?? null,
+                        },
+                        "製品一覧取得中にエラーが発生",
+                    );
+                    logAxiosError("get_fab_products", error);
+
+                    return {
+                        content: [{
+                            type: "text",
+                            text: isInvalidPageError
+                                ? `エラー: page=${resolvedPage} は無効です。別のページ番号を指定してください。`
+                                : `エラー: 製品一覧の取得中に問題が発生しました - ${errorMessage}`,
+                        }],
+                    };
+                }
+            },
+        );
+
         // ChatGPT向けに追加していた OpenAI 互換ツールは削除しました
     }
 }
@@ -707,7 +876,7 @@ export default {
                 name: "Flesh and Blood Card Search API",
                 version: "1.0.0",
                 description:
-                    "A Model Context Protocol server that provides card search, print variation listings, and detailed information for the Flesh and Blood Trading Card Game database.",
+                    "A Model Context Protocol server that provides card search, print variation listings, product catalogs, and detailed information for the Flesh and Blood Trading Card Game database.",
                 endpoints: {
                     sse: { url: `${origin}/sse` },
                     rpc: { url: `${origin}/mcp` },


### PR DESCRIPTION
## 概要
- `cardvault.fabtcg.com/products` のAPIを調査し、MCPツール `get_fab_products` を追加
- `GET /carddb/api/v1/product-groups-products/` を利用して製品グループ一覧とページング情報を返却
- README と調査ドキュメントにProducts APIの内容を追記

## 変更点
- `src/index.ts`
  - Product API用の型追加
  - `get_fab_products` ツール追加（`page` 任意、既定1）
  - ページングURLから `nextPage` / `previousPage` を抽出
  - 404 Invalid page 時のエラーメッセージを明確化
- `README.md`
  - 新ツール説明を追加
- `docs/cardvault-api-analysis.md`
  - Products API分析結果を追記

## 検証
- `yarn install` ✅
- `yarn tsc --noEmit` ✅
- `yarn dev` ✅（起動確認: `Ready on http://localhost:61589`）
- `yarn format` ❌ `command not found: biome`
- `yarn lint:fix` ❌ `command not found: biome`

## CI
- GitHub PR Checks: ✅ Pass
- Workers Builds: `fab-card-db-mcp` ✅ Pass
