### PR TITLE
fix: resolve missing biome command in yarn scripts

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -4,7 +4,7 @@
 		"enabled": true
 	},
 	"files": {
-		"ignore": ["worker-configuration.d.ts"]
+		"ignore": ["worker-configuration.d.ts", ".venv/**", ".mypy_cache/**"]
 	},
 	"vcs": {
 		"enabled": true,

--- a/package.json
+++ b/package.json
@@ -5,12 +5,13 @@
 	"scripts": {
 		"deploy": "wrangler deploy",
 		"dev": "wrangler dev",
-		"format": "biome format --write",
-		"lint:fix": "biome lint --fix",
+		"format": "biome format --write .",
+		"lint:fix": "biome lint --apply .",
 		"start": "wrangler dev",
 		"cf-typegen": "wrangler types"
 	},
 	"devDependencies": {
+		"@biomejs/biome": "1.6.2",
 		"@types/node": "^24.1.0",
 		"typescript": "^5.8.3",
 		"wrangler": "^4.26.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -55,6 +55,97 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@biomejs/biome@npm:1.6.2":
+  version: 1.6.2
+  resolution: "@biomejs/biome@npm:1.6.2"
+  dependencies:
+    "@biomejs/cli-darwin-arm64": "npm:1.6.2"
+    "@biomejs/cli-darwin-x64": "npm:1.6.2"
+    "@biomejs/cli-linux-arm64": "npm:1.6.2"
+    "@biomejs/cli-linux-arm64-musl": "npm:1.6.2"
+    "@biomejs/cli-linux-x64": "npm:1.6.2"
+    "@biomejs/cli-linux-x64-musl": "npm:1.6.2"
+    "@biomejs/cli-win32-arm64": "npm:1.6.2"
+    "@biomejs/cli-win32-x64": "npm:1.6.2"
+  dependenciesMeta:
+    "@biomejs/cli-darwin-arm64":
+      optional: true
+    "@biomejs/cli-darwin-x64":
+      optional: true
+    "@biomejs/cli-linux-arm64":
+      optional: true
+    "@biomejs/cli-linux-arm64-musl":
+      optional: true
+    "@biomejs/cli-linux-x64":
+      optional: true
+    "@biomejs/cli-linux-x64-musl":
+      optional: true
+    "@biomejs/cli-win32-arm64":
+      optional: true
+    "@biomejs/cli-win32-x64":
+      optional: true
+  bin:
+    biome: bin/biome
+  checksum: 10c0/a1b0c5a557469c7f8c8501a2d78a8eb91fc678d639faf0566ccaf84be7b8ee38956a1a47d10b227b60004217cad80e44730a55505a2d00b01327921a421706ca
+  languageName: node
+  linkType: hard
+
+"@biomejs/cli-darwin-arm64@npm:1.6.2":
+  version: 1.6.2
+  resolution: "@biomejs/cli-darwin-arm64@npm:1.6.2"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@biomejs/cli-darwin-x64@npm:1.6.2":
+  version: 1.6.2
+  resolution: "@biomejs/cli-darwin-x64@npm:1.6.2"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@biomejs/cli-linux-arm64-musl@npm:1.6.2":
+  version: 1.6.2
+  resolution: "@biomejs/cli-linux-arm64-musl@npm:1.6.2"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@biomejs/cli-linux-arm64@npm:1.6.2":
+  version: 1.6.2
+  resolution: "@biomejs/cli-linux-arm64@npm:1.6.2"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@biomejs/cli-linux-x64-musl@npm:1.6.2":
+  version: 1.6.2
+  resolution: "@biomejs/cli-linux-x64-musl@npm:1.6.2"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@biomejs/cli-linux-x64@npm:1.6.2":
+  version: 1.6.2
+  resolution: "@biomejs/cli-linux-x64@npm:1.6.2"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@biomejs/cli-win32-arm64@npm:1.6.2":
+  version: 1.6.2
+  resolution: "@biomejs/cli-win32-arm64@npm:1.6.2"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@biomejs/cli-win32-x64@npm:1.6.2":
+  version: 1.6.2
+  resolution: "@biomejs/cli-win32-x64@npm:1.6.2"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@cloudflare/kv-asset-handler@npm:0.4.0":
   version: 0.4.0
   resolution: "@cloudflare/kv-asset-handler@npm:0.4.0"
@@ -2431,6 +2522,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "remote-mcp-server-authless@workspace:."
   dependencies:
+    "@biomejs/biome": "npm:1.6.2"
     "@modelcontextprotocol/sdk": "npm:^1.13.3"
     "@types/node": "npm:^24.1.0"
     agents: "npm:^0.1.0"


### PR DESCRIPTION
## 概要
`yarn format` / `yarn lint:fix` で `command not found: biome` になる問題を解消します。

## 変更内容
- `@biomejs/biome` を `devDependencies` に追加（`1.6.2`）
- Biome 1.6系 CLI に合わせて scripts を修正
  - `format`: `biome format --write .`
  - `lint:fix`: `biome lint --apply .`
- ローカルの Python キャッシュ/仮想環境を対象外にするため、`biome.json` の ignore に以下を追加
  - `.venv/**`
  - `.mypy_cache/**`

## 検証
- `yarn format` ✅
- `yarn lint:fix` ✅
- `yarn tsc --noEmit` ✅

## CI
- Workers Builds: `fab-card-db-mcp` ✅ Pass
