### PR TITLE
fix: remove unsupported postUpgradeTasks from renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,13 +1,8 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
-  ],
-  "postUpgradeTasks": {
-    "executionMode": "branch",
-    "commands": [
-      "corepack enable",
-      "yarn install --mode=update-lockfile"
-    ]
-  }
+	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
+	"extends": ["config:recommended"],
+	"lockFileMaintenance": {
+		"enabled": true,
+		"schedule": ["before 3am on monday"]
+	}
 }


### PR DESCRIPTION
## Summary

- Mendホスト型Renovateで `postUpgradeTasks` のコマンド実行が常に失敗する問題を修正
- `postUpgradeTasks` ブロックを削除し、`lockFileMaintenance` を有効化

## Background

全てのRenovate PRが `renovate/artifacts` チェックで失敗していた。

## Root Cause

`renovate.json` の `postUpgradeTasks` に設定された `corepack enable` と `yarn install --mode=update-lockfile` が、Mendホスト型Renovateアプリでは実行を許可されていなかった。実行を許可する `allowedCommands` キーはセルフホスト型Renovate専用であり、リポジトリレベルの `renovate.json` では設定できない。

## Fix

- `postUpgradeTasks` ブロックを削除
  - Yarn Berry v4 ではRenovateがネイティブで `yarn.lock` を更新するため不要
- `lockFileMaintenance` を追加（毎週月曜 3:00 AM 前にロックファイルの整合性チェックを実施）

## Impact

- 既存のオープンなRenovate PRは、このPRをマージ後にRenovateがリベースすると自動的に回復する見込み
- 新規のRenovate PRでは `renovate/artifacts` チェックが正常に動作するようになる

## Test plan

- [ ] マージ後、Renovateが新しいPRを作成した際に `renovate/artifacts` チェックが成功することを確認
- [ ] 既存のオープンなRenovate PRがリベースされ、チェックが通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)