### PR TITLE
fix(renovate): remove postUpgradeTasks unsupported by hosted Renovate App

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,8 +1,4 @@
 {
 	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
-	"extends": ["config:recommended"],
-	"postUpgradeTasks": {
-		"executionMode": "branch",
-		"commands": ["corepack enable", "yarn install --mode=update-lockfile"]
-	}
+	"extends": ["config:recommended"]
 }


### PR DESCRIPTION
## 問題

全 Renovate PR（10件）で `renovate/artifacts` チェックが FAILURE になっています。

PR #86 での実際のエラーメッセージ（Renovate ボットコメントより）:

```
Post-upgrade command 'corepack enable' has not been added to the allowed list in allowedCommands
Post-upgrade command 'yarn install --mode=update-lockfile' has not been added to the allowed list in allowedCommands
```

ステータス API でも `"description": "Artifact file update failure"` として記録されています。

## 原因

`renovate.json` の `postUpgradeTasks`（`corepack enable` / `yarn install --mode=update-lockfile`）は **self-hosted Renovate 専用機能**です。

self-hosted Renovate では `allowedCommands` にコマンドを列挙することで `postUpgradeTasks` が実行されますが、**GitHub ホスト型 Renovate App にはこの設定が存在しません**。そのため、すべての Renovate PR で上記エラーが発生し、lockfile が更新されないまま `renovate/artifacts` が FAILURE になっていました。

## 修正

`postUpgradeTasks` ブロックを丸ごと削除しました。

Renovate は `package.json` の `packageManager: "yarn@4.9.4+sha512..."` フィールドを検出し、Yarn v4 (Berry) を **ネイティブにサポート**します。Corepack の有効化と `yarn install` は Renovate の組み込みアーティファクト更新処理が内部的に行うため、`postUpgradeTasks` は不要かつ有害でした。

## 期待される効果

このPRをマージすると、Renovate が次回実行時に全 PR を rebase して lockfile を再生成し、大半の `renovate/artifacts` FAILURE が解消される見込みです。

## 残る個別対応

- **#85（@biomejs/biome v2）**: `biome.json` が v1.6.2 スキーマのままのため、`renovate/artifacts` 解消後も `biome migrate` による v2 移行が別途必要です。